### PR TITLE
Gio.Application.register takes only one argument (cancellable)

### DIFF
--- a/src/share.js
+++ b/src/share.js
@@ -97,7 +97,7 @@ const Application = new Lang.Class({
             null
         );
         
-        this.register(null, null);
+        this.register(null);
     },
 
     vfunc_startup: function() {


### PR DESCRIPTION
The Gio.Application.register takes only one argument
A lot of those pop up 
```bash
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
Gjs-Message: JS WARNING: [/home/bilal/.local/share/gnome-shell/extensions/mconnect@andyholmes.github.io/share.js 100]: Too many arguments to method Gio.Application.register: expected 1, got 2
```
And here's the doc link: https://lazka.github.io/pgi-docs/#Gio-2.0/classes/Application.html#Gio.Application.register
