### PR TITLE
Make keywords translatable

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-mconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-19 14:53+0200\n"
-"PO-Revision-Date: 2017-08-19 14:55+0200\n"
+"POT-Creation-Date: 2017-08-20 10:56+0200\n"
+"PO-Revision-Date: 2017-08-20 10:56+0200\n"
 "Last-Translator: Jonatan Hatakeyama Zeidler <jonatan_zeidler@gmx.de>\n"
 "Language-Team: Jonatan Hatakeyama Zeidler\n"
 "Language: de\n"
@@ -18,51 +18,59 @@ msgstr ""
 "X-Generator: Poedit 2.0.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/extension.js:267
+#: src/extension.js:33
+msgid "OFFLINE"
+msgstr "Nicht verbunden"
+
+#: src/extension.js:34
+msgid "UNPAIRED"
+msgstr "Nicht gekoppelt"
+
+#: src/extension.js:272
 msgid "Device is unpaired"
 msgstr "Gerät ist nicht gekoppelt"
 
-#: src/extension.js:270 src/sms.js:424
+#: src/extension.js:275 src/sms.js:458
 msgid "Device is offline"
 msgstr "Gerät ist nicht verbunden"
 
-#: src/extension.js:308
+#: src/extension.js:313
 msgid "Failed to mount device filesystem"
 msgstr "Einhängen des Gerätedateisystems fehlgeschlagen"
 
-#: src/extension.js:448
+#: src/extension.js:453
 msgid "Mobile Devices"
 msgstr "Mobile Geräte"
 
-#: src/extension.js:466
+#: src/extension.js:471
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: src/extension.js:472
+#: src/extension.js:477
 msgid "Mobile Settings"
 msgstr "Einstellungen Mobile Geräte"
 
-#: src/extension.js:513
+#: src/extension.js:518
 msgid "Stop scanning for Devices"
 msgstr "Suche nach Geräten abbrechen"
 
-#: src/extension.js:515
+#: src/extension.js:520
 msgid "Scan for Devices"
 msgstr "Geräte suchen"
 
-#: src/extension.js:570 src/extension.js:595
+#: src/extension.js:575 src/extension.js:600
 msgid "Scanning for device..."
 msgstr "Gerät werden gesucht …"
 
-#: src/extension.js:641
+#: src/extension.js:646
 msgid "Nautilus extensions changed"
 msgstr "Nautilus-Erweiterungen wurden geändert"
 
-#: src/extension.js:642
+#: src/extension.js:647
 msgid "Restart Nautilus to apply changes"
 msgstr "Nautilus neustarten, um Änderungen zu übernehmen"
 
-#: src/extension.js:647
+#: src/extension.js:652
 msgid "Restart"
 msgstr "Neustart"
 
@@ -114,19 +122,19 @@ msgstr "Senden"
 msgid "MConnect File Share"
 msgstr "MConnect Dateitransfer"
 
-#: src/sms.js:313
+#: src/sms.js:347
 msgid "Type a phone number"
 msgstr "Telefonnummer eingeben"
 
-#: src/sms.js:322
+#: src/sms.js:356
 msgid "Type a phone number or name"
 msgstr "Telefonnummer oder Name eingeben"
 
-#: src/sms.js:461
+#: src/sms.js:495
 msgid "Type an SMS message"
 msgstr "SMS-Nachricht eingeben"
 
-#: src/sms.js:576
+#: src/sms.js:610
 msgid "MConnect SMS"
 msgstr "MConnect SMS"
 

--- a/po/gnome-shell-extension-mconnect.pot
+++ b/po/gnome-shell-extension-mconnect.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gnome-shell-extension-mconnect\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-08-18 21:30-0700\n"
+"POT-Creation-Date: 2017-08-20 10:56+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,51 +18,59 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/extension.js:267
+#: src/extension.js:33
+msgid "OFFLINE"
+msgstr ""
+
+#: src/extension.js:34
+msgid "UNPAIRED"
+msgstr ""
+
+#: src/extension.js:272
 msgid "Device is unpaired"
 msgstr ""
 
-#: src/extension.js:270 src/sms.js:424
+#: src/extension.js:275 src/sms.js:458
 msgid "Device is offline"
 msgstr ""
 
-#: src/extension.js:308
+#: src/extension.js:313
 msgid "Failed to mount device filesystem"
 msgstr ""
 
-#: src/extension.js:448
+#: src/extension.js:453
 msgid "Mobile Devices"
 msgstr ""
 
-#: src/extension.js:466
+#: src/extension.js:471
 msgid "Enable"
 msgstr ""
 
-#: src/extension.js:472
+#: src/extension.js:477
 msgid "Mobile Settings"
 msgstr ""
 
-#: src/extension.js:513
+#: src/extension.js:518
 msgid "Stop scanning for Devices"
 msgstr ""
 
-#: src/extension.js:515
+#: src/extension.js:520
 msgid "Scan for Devices"
 msgstr ""
 
-#: src/extension.js:570 src/extension.js:595
+#: src/extension.js:575 src/extension.js:600
 msgid "Scanning for device..."
 msgstr ""
 
-#: src/extension.js:641
+#: src/extension.js:646
 msgid "Nautilus extensions changed"
 msgstr ""
 
-#: src/extension.js:642
+#: src/extension.js:647
 msgid "Restart Nautilus to apply changes"
 msgstr ""
 
-#: src/extension.js:647
+#: src/extension.js:652
 msgid "Restart"
 msgstr ""
 
@@ -114,19 +122,19 @@ msgstr ""
 msgid "MConnect File Share"
 msgstr ""
 
-#: src/sms.js:313
+#: src/sms.js:347
 msgid "Type a phone number"
 msgstr ""
 
-#: src/sms.js:322
+#: src/sms.js:356
 msgid "Type a phone number or name"
 msgstr ""
 
-#: src/sms.js:461
+#: src/sms.js:495
 msgid "Type an SMS message"
 msgstr ""
 
-#: src/sms.js:576
+#: src/sms.js:610
 msgid "MConnect SMS"
 msgstr ""
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -29,6 +29,11 @@ var DeviceVisibility = {
     UNPAIRED: 2
 };
 
+var DeviceVisibilityNames = {
+    OFFLINE: _("OFFLINE"),
+    UNPAIRED: _("UNPAIRED")
+};
+
 var ServiceProvider = {
     MCONNECT: 0,
     KDECONNECT: 1

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -56,7 +56,7 @@ const EnumSetting = new Lang.Class({
         let enums = key.get_range().deep_unpack()[1].deep_unpack();
         
         enums.forEach((enum_nick) => {
-            this.append(enum_nick, enum_nick); // TODO: better
+            this.append(enum_nick, _(enum_nick)); // TODO: better
         });
         
         this.active_id = Settings.get_string(setting);
@@ -104,7 +104,7 @@ const FlagsSetting = new Lang.Class({
         
         flags.forEach((flagNick) => {
             flag = new Gtk.CheckButton({
-                label: flagNick,
+                label: _(flagNick),
                 visible: true,
                 active: (old_flags.indexOf(flagNick) > -1)
             });
@@ -113,9 +113,9 @@ const FlagsSetting = new Lang.Class({
                 let new_flags = Settings.get_value(setting).deep_unpack();
                 
                 if (button.active) {
-                    new_flags.push(button.label);
+                    new_flags.push(flagNick);
                 } else {
-                    new_flags.splice(new_flags.indexOf(button.label), 1);
+                    new_flags.splice(new_flags.indexOf(flagNick), 1);
                 }
                 
                 Settings.set_value(setting, new GLib.Variant("as", new_flags));
@@ -358,7 +358,7 @@ const OtherSetting = new Lang.Class({
     }
 });
 
-/** A composite widget for GSettings resmbling Gnome Control Center panels. */
+/** A composite widget for GSettings resampling Gnome Control Center panels. */
 const SettingsWidget = new Lang.Class({
     Name: "SettingsWidget",
     Extends: Gtk.ScrolledWindow,


### PR DESCRIPTION
This is just my first shot, but it seems to work. I did:

- Add a [keyword dictionary](https://github.com/jonnius/gnome-shell-extension-mconnect/commit/b3a05d911898b60c04100a51d12fbef280ea543c#diff-0d6066687fab7c23ea750de2a8756d39R32) to introduce the keywords to gettext.
- Let gettext translate the [widget label](https://github.com/jonnius/gnome-shell-extension-mconnect/commit/b3a05d911898b60c04100a51d12fbef280ea543c#diff-f3b2dbd7db51b8250f6ceed309af28f8R107)
- Don't use the label to identify the selection. [Use the keyword](https://github.com/jonnius/gnome-shell-extension-mconnect/commit/b3a05d911898b60c04100a51d12fbef280ea543c#diff-f3b2dbd7db51b8250f6ceed309af28f8R116) instead 